### PR TITLE
Bump model-validation-cli to v1.0.1

### DIFF
--- a/.github/workflows/sign-model.yaml
+++ b/.github/workflows/sign-model.yaml
@@ -30,7 +30,7 @@ jobs:
       env:
         OIDC_TOKEN: ${{ env.OIDC_TOKEN }}
       run: |
-        docker run --rm -v $(pwd)/testdata/tensorflow_saved_model:/tensorflow_saved_model:z -w /tensorflow_saved_model ghcr.io/miyunari/model-transparency-cli:latest sign --sig_out=/tensorflow_saved_model/model.sig --model_path=/tensorflow_saved_model sigstore --identity-token "$OIDC_TOKEN"
+        docker run --rm -v $(pwd)/testdata/tensorflow_saved_model:/tensorflow_saved_model:z -w /tensorflow_saved_model ghcr.io/miyunari/model-transparency-cli:latest sign sigstore --signature="/tensorflow_saved_model/model.sig" --identity_token "$OIDC_TOKEN" /tensorflow_saved_model
 
     - name: Create tar.gz of the signed model
       run: |

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: model-validation-controller-sa
       containers:
       - name: model-validation-controller
-        image: ghcr.io/miyunari/model-validation-controller:latest
+        image: ghcr.io/miyunari/model-validation-controller:v1.0.1
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -2,7 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: model-validation-controller
+
 resources:
+ - namespace.yaml
  - crd.yaml
  - clusterrole.yaml
  - service_account.yaml

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: model-validation-controller


### PR DESCRIPTION
- Use the offical released image `ghcr.io/sigstore/model-transparency-cli:v1.0.1`.
  - Update signing step in github action.
  - Update controller.