### PR TITLE
feat: add legacy sidecar support for pre-1.28 Kubernetes clusters

### DIFF
--- a/api/v1alpha1/modelvalidation_types.go
+++ b/api/v1alpha1/modelvalidation_types.go
@@ -116,14 +116,15 @@ type ValidationConfig struct {
 }
 
 // ContinuousValidation defines the configuration for continuous model validation.
-// When enabled, the validation container runs as a native sidecar with restartPolicy: Always,
-// allowing periodic re-validation of the model.
-// Note: Native sidecar support requires Kubernetes 1.28+ with the feature explicitly enabled,
-// or Kubernetes 1.29+ where it is enabled by default.
+// When enabled, the validation container periodically re-validates the model.
+// On Kubernetes 1.28+ (with SidecarContainers feature gate) or 1.29+ (enabled by default),
+// this uses a native sidecar (init container with restartPolicy: Always).
+// On older clusters, the operator falls back to injecting a one-shot init container
+// for initial validation plus a traditional sidecar container for periodic re-validation.
 type ContinuousValidation struct {
 	// Enabled controls whether continuous validation is active.
-	// When true, the validation container runs as a native sidecar with restartPolicy: Always.
-	// When false (default), the validation container runs as a standard init container.
+	// When true, the validation container periodically re-validates the model.
+	// When false (default), the validation container runs as a standard init container (one-shot).
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled"`
 
@@ -154,8 +155,8 @@ type ModelValidationSpec struct {
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// ContinuousValidation enables periodic re-validation of the model.
-	// When enabled, the init container becomes a native sidecar.
-	// Requires Kubernetes 1.28+ with SidecarContainers feature gate enabled, or 1.29+ (enabled by default).
+	// On Kubernetes 1.28+, uses a native sidecar. On older clusters, falls back to
+	// a traditional sidecar container alongside a one-shot init container.
 	// +kubebuilder:validation:Optional
 	ContinuousValidation *ContinuousValidation `json:"continuousValidation,omitempty"`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -281,8 +281,15 @@ func main() {
 	}
 
 	if !disableWebhook {
+		nativeSidecarSupport, err := webhooks.NativeSidecarSupport(mgr.GetConfig())
+		if err != nil {
+			setupLog.Error(err, "failed to detect native sidecar support, assuming not supported")
+			nativeSidecarSupport = false
+		}
+		setupLog.Info("Kubernetes sidecar support detected", "nativeSidecars", nativeSidecarSupport)
+
 		decoder := admission.NewDecoder(mgr.GetScheme())
-		interceptor := webhooks.NewPodInterceptor(mgr.GetClient(), decoder)
+		interceptor := webhooks.NewPodInterceptor(mgr.GetClient(), decoder, nativeSidecarSupport)
 		mgr.GetWebhookServer().Register("/mutate-v1-pod", &admission.Webhook{
 			Handler: interceptor,
 		})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var disableWebhook bool
+	var forceLegacySidecar bool
 	var tlsOpts []func(*tls.Config)
 
 	// Status tracker configuration
@@ -108,6 +109,9 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.BoolVar(&disableWebhook, "disable-webhook", false,
 		"Disable the webhook server for development environments without certificates.")
+	utils.BoolFlagOrEnv(&forceLegacySidecar, "force-legacy-sidecar",
+		"FORCE_LEGACY_SIDECAR", false,
+		"Force legacy sidecar mode for continuous validation, even on clusters that support native sidecars.")
 	utils.StringFlagOrEnv(&constants.ModelValidationAgentImage,
 		"validation-agent-image",
 		"VALIDATION_AGENT_IMAGE",
@@ -286,7 +290,11 @@ func main() {
 			setupLog.Error(err, "failed to detect native sidecar support, assuming not supported")
 			nativeSidecarSupport = false
 		}
-		setupLog.Info("Kubernetes sidecar support detected", "nativeSidecars", nativeSidecarSupport)
+		if forceLegacySidecar {
+			setupLog.Info("Forcing legacy sidecar mode (--force-legacy-sidecar is set)")
+			nativeSidecarSupport = false
+		}
+		setupLog.Info("Kubernetes sidecar support", "nativeSidecars", nativeSidecarSupport)
 
 		decoder := admission.NewDecoder(mgr.GetScheme())
 		interceptor := webhooks.NewPodInterceptor(mgr.GetClient(), decoder, nativeSidecarSupport)

--- a/cmd/validation-agent/main.go
+++ b/cmd/validation-agent/main.go
@@ -33,15 +33,18 @@ var (
 func main() {
 	var interval time.Duration
 	var healthPort int
+	var skipInitial bool
 
 	flag.DurationVar(&interval, "interval", 0, "Validation interval (e.g., 5m, 1h). If 0 or not set, runs once and exits.")
 	flag.IntVar(&healthPort, "health-port", 8080, "Health check server port")
+	flag.BoolVar(&skipInitial, "skip-initial", false,
+		"Skip initial validation (used with legacy sidecar mode where init container already validated)")
 	flag.Parse()
 
 	log.SetLogger(zap.New())
 	logger := log.Log.WithName("validation-agent")
 
-	logger.Info("Starting validation agent", "interval", interval, "healthPort", healthPort)
+	logger.Info("Starting validation agent", "interval", interval, "healthPort", healthPort, "skipInitial", skipInitial)
 
 	// Setup signal handling
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
@@ -72,18 +75,23 @@ func main() {
 	// Validation args are remaining flags (passed to model-transparency-cli)
 	validationArgs := flag.Args()
 
-	// Run initial validation
-	logger.Info("Running initial validation")
-	if err := runValidation(ctx, validationArgs, logger, "initial"); err != nil {
-		logger.Error(err, "Initial validation failed")
-		if interval == 0 {
-			// One-shot mode: exit with error
-			os.Exit(1)
-		}
-		// Continuous mode: don't mark ready, but continue (will retry)
-	} else {
-		logger.Info("Initial validation successful")
+	// Run initial validation (unless skipped for legacy sidecar mode)
+	if skipInitial {
+		logger.Info("Skipping initial validation (init container already validated)")
 		markReady()
+	} else {
+		logger.Info("Running initial validation")
+		if err := runValidation(ctx, validationArgs, logger, "initial"); err != nil {
+			logger.Error(err, "Initial validation failed")
+			if interval == 0 {
+				// One-shot mode: exit with error
+				os.Exit(1)
+			}
+			// Continuous mode: don't mark ready, but continue (will retry)
+		} else {
+			logger.Info("Initial validation successful")
+			markReady()
+		}
 	}
 
 	// Continuous validation loop

--- a/config/crd/bases/ml.sigstore.dev_modelvalidations.yaml
+++ b/config/crd/bases/ml.sigstore.dev_modelvalidations.yaml
@@ -128,15 +128,15 @@ spec:
               continuousValidation:
                 description: |-
                   ContinuousValidation enables periodic re-validation of the model.
-                  When enabled, the init container becomes a native sidecar.
-                  Requires Kubernetes 1.28+ with SidecarContainers feature gate enabled, or 1.29+ (enabled by default).
+                  On Kubernetes 1.28+, uses a native sidecar. On older clusters, falls back to
+                  a traditional sidecar container alongside a one-shot init container.
                 properties:
                   enabled:
                     default: false
                     description: |-
                       Enabled controls whether continuous validation is active.
-                      When true, the validation container runs as a native sidecar with restartPolicy: Always.
-                      When false (default), the validation container runs as a standard init container.
+                      When true, the validation container periodically re-validates the model.
+                      When false (default), the validation container runs as a standard init container (one-shot).
                     type: boolean
                   interval:
                     default: 5m

--- a/internal/constants/images.go
+++ b/internal/constants/images.go
@@ -18,6 +18,10 @@ package constants
 const (
 	// ModelValidationInitContainerName is the name of the init container injected for model validation
 	ModelValidationInitContainerName = "model-validation"
+
+	// ModelValidationSidecarContainerName is the name of the regular sidecar container
+	// used for continuous validation on clusters that don't support native sidecars (pre-1.28)
+	ModelValidationSidecarContainerName = "model-validation-sidecar"
 )
 
 var (

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -29,3 +29,14 @@ func StringFlagOrEnv(p *string, name string, envName string, defaultValue string
 	}
 	flag.StringVar(p, name, defaultValue, usage)
 }
+
+// BoolFlagOrEnv defines a bool flag which can be set by an environment variable.
+// Precedence: flag > env var > default value.
+// The env var is considered true if set to "true", "1", or "yes" (case-insensitive).
+func BoolFlagOrEnv(p *bool, name string, envName string, defaultValue bool, usage string) {
+	envValue := os.Getenv(envName)
+	if envValue == "true" || envValue == "1" || envValue == "yes" {
+		defaultValue = true
+	}
+	flag.BoolVar(p, name, defaultValue, usage)
+}

--- a/internal/webhooks/pod_webhook.go
+++ b/internal/webhooks/pod_webhook.go
@@ -38,11 +38,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// NewPodInterceptor creates a new pod mutating webhook to be registered
-func NewPodInterceptor(c client.Client, decoder admission.Decoder) webhook.AdmissionHandler {
+// NewPodInterceptor creates a new pod mutating webhook to be registered.
+// nativeSidecarSupport indicates whether the cluster supports native sidecars
+// (init containers with restartPolicy: Always, available in Kubernetes 1.28+).
+// When false, continuous validation falls back to injecting a traditional sidecar
+// container alongside a one-shot init container.
+func NewPodInterceptor(c client.Client, decoder admission.Decoder, nativeSidecarSupport bool) webhook.AdmissionHandler {
 	return &podInterceptor{
-		client:  c,
-		decoder: decoder,
+		client:               c,
+		decoder:              decoder,
+		nativeSidecarSupport: nativeSidecarSupport,
 	}
 }
 
@@ -55,8 +60,9 @@ func NewPodInterceptor(c client.Client, decoder admission.Decoder) webhook.Admis
 
 // podInterceptor extends pods with Model Validation Init-Container if annotation is specified.
 type podInterceptor struct {
-	client  client.Client
-	decoder admission.Decoder
+	client               client.Client
+	decoder              admission.Decoder
+	nativeSidecarSupport bool
 }
 
 // Handle extends pods with Model Validation Init-Container if annotation is specified.
@@ -104,6 +110,11 @@ func (p *podInterceptor) Handle(ctx context.Context, req admission.Request) admi
 			return admission.Allowed("validation exists, no action needed")
 		}
 	}
+	for _, c := range pod.Spec.Containers {
+		if c.Name == constants.ModelValidationSidecarContainerName {
+			return admission.Allowed("validation exists, no action needed")
+		}
+	}
 
 	mergedModel := mergeModelWithAnnotations(logger, mv.Spec.Model, pod.Annotations)
 
@@ -131,8 +142,22 @@ func (p *podInterceptor) Handle(ctx context.Context, req admission.Request) admi
 		vm = append(vm, c.VolumeMounts...)
 	}
 
-	container := buildValidationContainer(mv, args, vm, pp, tc)
+	continuousEnabled := mv.Spec.ContinuousValidation != nil && mv.Spec.ContinuousValidation.Enabled
+	useLegacySidecar := continuousEnabled && !p.nativeSidecarSupport
+
+	if useLegacySidecar {
+		logger.Info("Using legacy sidecar for continuous validation (native sidecars not supported)")
+	}
+
+	container := buildValidationContainer(mv, args, vm, pp, tc, p.nativeSidecarSupport)
 	pp.Spec.InitContainers = append(pp.Spec.InitContainers, container)
+
+	// On pre-1.28 clusters with continuous validation, inject a traditional sidecar
+	// container alongside the init container for periodic re-validation.
+	if useLegacySidecar {
+		sidecar := buildLegacySidecarContainer(mv, args, vm, pp)
+		pp.Spec.Containers = append(pp.Spec.Containers, sidecar)
+	}
 
 	marshaledPod, err := json.Marshal(pp)
 	if err != nil {
@@ -142,12 +167,9 @@ func (p *podInterceptor) Handle(ctx context.Context, req admission.Request) admi
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }
 
-// buildValidationContainer constructs the validation container with appropriate configuration
-// for either one-shot or continuous validation based on ModelValidation spec.
-// If a TelemetryConfig is provided, OTEL_* environment variables are injected.
 func buildValidationContainer(
 	mv *v1alpha1.ModelValidation, args []string, vm []corev1.VolumeMount, pp *corev1.Pod,
-	tc *v1alpha1.TelemetryConfig,
+	tc *v1alpha1.TelemetryConfig, nativeSidecarSupport bool,
 ) corev1.Container {
 	// Determine image pull policy
 	imagePullPolicy := corev1.PullAlways
@@ -164,8 +186,9 @@ func buildValidationContainer(
 		VolumeMounts:    vm,
 	}
 
-	// Add continuous validation configuration if enabled
-	if mv.Spec.ContinuousValidation != nil && mv.Spec.ContinuousValidation.Enabled {
+	// Add continuous validation configuration if enabled AND native sidecars are supported
+	continuousEnabled := mv.Spec.ContinuousValidation != nil && mv.Spec.ContinuousValidation.Enabled
+	if continuousEnabled && nativeSidecarSupport {
 		interval := "5m"
 		if mv.Spec.ContinuousValidation.Interval != "" {
 			interval = mv.Spec.ContinuousValidation.Interval
@@ -200,8 +223,10 @@ func buildValidationContainer(
 			InitialDelaySeconds: 10,
 			PeriodSeconds:       30,
 		}
+	}
 
-		// Add annotation to track continuous validation (for informational/tracking purposes)
+	// Track continuous validation in annotations regardless of sidecar mode
+	if continuousEnabled {
 		if pp.Annotations == nil {
 			pp.Annotations = make(map[string]string)
 		}
@@ -227,6 +252,79 @@ func buildValidationContainer(
 	// Inject telemetry env vars if a TelemetryConfig matched
 	if envs := telemetryEnvVars(tc); len(envs) > 0 {
 		container.Env = append(container.Env, envs...)
+	}
+
+	return container
+}
+
+// buildLegacySidecarContainer constructs a traditional sidecar container for
+// continuous validation on clusters that don't support native sidecars (pre-1.28).
+// This container runs alongside the application containers and periodically
+// re-validates the model. The init container (built by buildValidationContainer)
+// handles the initial one-shot validation to block pod startup.
+func buildLegacySidecarContainer(
+	mv *v1alpha1.ModelValidation, args []string, vm []corev1.VolumeMount, _ *corev1.Pod,
+) corev1.Container {
+	imagePullPolicy := corev1.PullAlways
+	if mv.Spec.ImagePullPolicy != "" {
+		imagePullPolicy = mv.Spec.ImagePullPolicy
+	}
+
+	interval := "5m"
+	if mv.Spec.ContinuousValidation != nil && mv.Spec.ContinuousValidation.Interval != "" {
+		interval = mv.Spec.ContinuousValidation.Interval
+	}
+
+	// Prepend interval flag and --skip-initial to args.
+	// --skip-initial tells the agent to skip initial validation since the
+	// init container already performed it.
+	sidecarArgs := append([]string{"--interval=" + interval, "--skip-initial"}, args...)
+
+	container := corev1.Container{
+		Name:            constants.ModelValidationSidecarContainerName,
+		Image:           constants.ModelValidationAgentImage,
+		ImagePullPolicy: imagePullPolicy,
+		Command:         []string{"/usr/local/bin/validation-agent"},
+		Args:            sidecarArgs,
+		VolumeMounts:    vm,
+		// Add readiness probe (ready immediately since init container already validated)
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/ready",
+					Port: intstr.FromInt(8080),
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+		},
+		// Add liveness probe
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.FromInt(8080),
+				},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       30,
+		},
+	}
+
+	// Apply resource requirements
+	if mv.Spec.Resources != nil {
+		container.Resources = *mv.Spec.Resources
+	} else {
+		container.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		}
 	}
 
 	return container

--- a/internal/webhooks/pod_webhook_legacy_test.go
+++ b/internal/webhooks/pod_webhook_legacy_test.go
@@ -1,0 +1,303 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	"github.com/sigstore/model-validation-operator/api/v1alpha1"
+	"github.com/sigstore/model-validation-operator/internal/constants"
+	"github.com/sigstore/model-validation-operator/internal/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Legacy sidecar support", func() {
+	Context("buildValidationContainer with nativeSidecarSupport=false", func() {
+		It("Should not set restartPolicy even when continuous validation is enabled", func() {
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:       "test-mv",
+				Namespace:  "default",
+				ConfigType: "sigstore",
+			})
+			mv.Spec.ContinuousValidation = &v1alpha1.ContinuousValidation{
+				Enabled:  true,
+				Interval: "10m",
+			}
+
+			pp := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: make(map[string]string),
+				},
+			}
+
+			args := []string{"verify", "sigstore", "--signature=/sig", "/model"}
+			container := buildValidationContainer(mv, args, nil, pp, nil, false)
+
+			Expect(container.Name).To(Equal(constants.ModelValidationInitContainerName))
+			Expect(container.RestartPolicy).To(BeNil(), "restartPolicy should not be set for legacy mode")
+			Expect(container.Args).To(Equal(args), "args should be one-shot (no --interval)")
+			Expect(container.ReadinessProbe).To(BeNil(), "no probes for one-shot init container")
+			Expect(container.LivenessProbe).To(BeNil(), "no probes for one-shot init container")
+			Expect(pp.Annotations[constants.ContinuousValidationAnnotationKey]).To(Equal("true"),
+				"continuous validation annotation should still be set")
+		})
+
+		It("Should set restartPolicy when nativeSidecarSupport=true and continuous validation is enabled", func() {
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:       "test-mv",
+				Namespace:  "default",
+				ConfigType: "sigstore",
+			})
+			mv.Spec.ContinuousValidation = &v1alpha1.ContinuousValidation{
+				Enabled:  true,
+				Interval: "10m",
+			}
+
+			pp := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: make(map[string]string),
+				},
+			}
+
+			args := []string{"verify", "sigstore", "--signature=/sig", "/model"}
+			container := buildValidationContainer(mv, args, nil, pp, nil, true)
+
+			Expect(container.RestartPolicy).NotTo(BeNil(), "restartPolicy should be set for native sidecar")
+			Expect(*container.RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
+			Expect(container.Args[0]).To(Equal("--interval=10m"))
+			Expect(container.ReadinessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe).NotTo(BeNil())
+		})
+	})
+
+	Context("buildLegacySidecarContainer", func() {
+		It("Should create a sidecar with --interval and --skip-initial flags", func() {
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:       "test-mv",
+				Namespace:  "default",
+				ConfigType: "sigstore",
+			})
+			mv.Spec.ContinuousValidation = &v1alpha1.ContinuousValidation{
+				Enabled:  true,
+				Interval: "15m",
+			}
+
+			pp := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: make(map[string]string),
+				},
+			}
+
+			args := []string{"verify", "sigstore", "--signature=/sig", "/model"}
+			container := buildLegacySidecarContainer(mv, args, nil, pp)
+
+			Expect(container.Name).To(Equal(constants.ModelValidationSidecarContainerName))
+			Expect(container.RestartPolicy).To(BeNil(), "regular containers don't use restartPolicy")
+			Expect(container.Args[0]).To(Equal("--interval=15m"))
+			Expect(container.Args[1]).To(Equal("--skip-initial"))
+			Expect(container.Args[2:]).To(Equal(args))
+			Expect(container.ReadinessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/ready"))
+			Expect(container.LivenessProbe.HTTPGet.Path).To(Equal("/healthz"))
+		})
+
+		It("Should use default interval when not specified", func() {
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:       "test-mv",
+				Namespace:  "default",
+				ConfigType: "sigstore",
+			})
+			mv.Spec.ContinuousValidation = &v1alpha1.ContinuousValidation{
+				Enabled: true,
+			}
+
+			pp := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: make(map[string]string),
+				},
+			}
+
+			args := []string{"verify", "sigstore", "--signature=/sig", "/model"}
+			container := buildLegacySidecarContainer(mv, args, nil, pp)
+
+			Expect(container.Args[0]).To(Equal("--interval=5m"))
+		})
+	})
+
+	Context("Legacy sidecar webhook integration", func() {
+		It("Should inject both init container and sidecar on pre-1.28 cluster with continuous validation", func() {
+			legacyNs := fmt.Sprintf("legacy-ns-%d", time.Now().UnixNano())
+
+			By("Creating namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: legacyNs},
+			}
+			err := k8sClient.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating ModelValidation with continuous validation enabled")
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:           "legacy-test",
+				Namespace:      legacyNs,
+				ConfigType:     "sigstore",
+				CertIdentity:   "legacy@example.com",
+				CertOidcIssuer: "https://accounts.google.com",
+				ModelPath:      "/path/to/model",
+				SignaturePath:  "/path/to/model.sig",
+			})
+			mv.Spec.ContinuousValidation = &v1alpha1.ContinuousValidation{
+				Enabled:  true,
+				Interval: "10m",
+			}
+			err = k8sClient.Create(ctx, mv)
+			Expect(err).NotTo(HaveOccurred())
+
+			statusTracker.AddModelValidation(ctx, mv)
+
+			By("Registering a legacy-mode webhook on a separate path")
+			// We can't replace the main webhook, so we test via the build functions directly.
+			// The integration test above already covers native mode. Here we verify the
+			// build functions produce the correct output for legacy mode.
+
+			args := []string{"verify", "sigstore", "--signature=/path/to/model.sig",
+				"--identity", "legacy@example.com",
+				"--identity_provider", "https://accounts.google.com",
+				"/path/to/model"}
+
+			pp := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: make(map[string]string),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "app:latest"},
+					},
+				},
+			}
+
+			initContainer := buildValidationContainer(mv, args, nil, pp, nil, false)
+			sidecar := buildLegacySidecarContainer(mv, args, nil, pp)
+
+			By("Verifying init container is one-shot")
+			Expect(initContainer.RestartPolicy).To(BeNil())
+			Expect(initContainer.Args).To(Equal(args))
+			Expect(initContainer.ReadinessProbe).To(BeNil())
+
+			By("Verifying sidecar has continuous validation config")
+			Expect(sidecar.Name).To(Equal(constants.ModelValidationSidecarContainerName))
+			Expect(sidecar.Args[0]).To(Equal("--interval=10m"))
+			Expect(sidecar.Args[1]).To(Equal("--skip-initial"))
+			Expect(sidecar.ReadinessProbe).NotTo(BeNil())
+			Expect(sidecar.LivenessProbe).NotTo(BeNil())
+
+			By("Verifying continuous validation annotation is set")
+			Expect(pp.Annotations[constants.ContinuousValidationAnnotationKey]).To(Equal("true"))
+
+			By("Cleanup")
+			_ = k8sClient.Delete(ctx, &v1alpha1.ModelValidation{
+				ObjectMeta: metav1.ObjectMeta{Name: "legacy-test", Namespace: legacyNs},
+			})
+			_ = k8sClient.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: legacyNs},
+			})
+		})
+
+		It("Should not inject sidecar when continuous validation is disabled on legacy cluster", func() {
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:       "oneshot-test",
+				Namespace:  "default",
+				ConfigType: "sigstore",
+			})
+			// No continuous validation
+
+			pp := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: make(map[string]string),
+				},
+			}
+
+			args := []string{"verify", "sigstore", "--signature=/sig", "/model"}
+			container := buildValidationContainer(mv, args, nil, pp, nil, false)
+
+			Expect(container.RestartPolicy).To(BeNil())
+			Expect(container.Args).To(Equal(args))
+			Expect(pp.Annotations).NotTo(HaveKey(constants.ContinuousValidationAnnotationKey))
+		})
+	})
+
+	Context("Idempotency check for legacy sidecar", func() {
+		It("Should skip injection if legacy sidecar container already exists", func() {
+			legacyIdempotentNs := fmt.Sprintf("legacy-idemp-ns-%d", time.Now().UnixNano())
+
+			By("Creating namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: legacyIdempotentNs},
+			}
+			err := k8sClient.Create(context.Background(), ns)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating ModelValidation")
+			mv := testutil.CreateTestModelValidation(testutil.TestModelValidationOptions{
+				Name:           "idemp-test",
+				Namespace:      legacyIdempotentNs,
+				ConfigType:     "sigstore",
+				CertIdentity:   "idemp@example.com",
+				CertOidcIssuer: "https://accounts.google.com",
+			})
+			err = k8sClient.Create(context.Background(), mv)
+			Expect(err).NotTo(HaveOccurred())
+
+			statusTracker.AddModelValidation(ctx, mv)
+
+			By("Creating pod with existing sidecar container")
+			pod := testutil.CreateTestPod(testutil.TestPodOptions{
+				Name:      "idemp-pod",
+				Namespace: legacyIdempotentNs,
+				Labels:    map[string]string{constants.ModelValidationLabel: "idemp-test"},
+			})
+			// Pre-add the sidecar container to simulate already-injected state
+			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+				Name:  constants.ModelValidationSidecarContainerName,
+				Image: constants.ModelValidationAgentImage,
+			})
+			err = k8sClient.Create(context.Background(), pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying pod was not double-injected")
+			found := &corev1.Pod{}
+			Eventually(context.Background(), func(ctx context.Context) error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name: "idemp-pod", Namespace: legacyIdempotentNs,
+				}, found)
+			}, 5*time.Second).Should(Succeed())
+
+			// Should not have init containers added since sidecar was already present
+			Expect(found.Spec.InitContainers).To(BeEmpty(),
+				"init containers should not be injected when sidecar already exists")
+
+			By("Cleanup")
+			_ = k8sClient.Delete(context.Background(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: legacyIdempotentNs},
+			})
+		})
+	})
+})

--- a/internal/webhooks/suite_test.go
+++ b/internal/webhooks/suite_test.go
@@ -158,7 +158,9 @@ var _ = BeforeSuite(func() {
 		RateLimitBurst:      1000,                  // Higher burst for tests
 		StatusUpdateTimeout: 5 * time.Second,       // Shorter timeout for tests
 	})
-	podWebhookHandler := NewPodInterceptor(mgr.GetClient(), decoder)
+	// Use native sidecar support=true since envtest uses modern K8s binaries.
+	// Legacy sidecar behavior is tested separately via unit tests.
+	podWebhookHandler := NewPodInterceptor(mgr.GetClient(), decoder, true)
 	mgr.GetWebhookServer().Register("/mutate-v1-pod", &admission.Webhook{
 		Handler: podWebhookHandler,
 	})

--- a/internal/webhooks/version.go
+++ b/internal/webhooks/version.go
@@ -1,0 +1,60 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// NativeSidecarSupport checks whether the Kubernetes cluster supports native
+// sidecar containers (init containers with restartPolicy: Always).
+// Native sidecars require Kubernetes 1.28+ (with SidecarContainers feature gate)
+// or 1.29+ (where the feature gate is enabled by default).
+func NativeSidecarSupport(cfg *rest.Config) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return false, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	serverVersion, err := dc.ServerVersion()
+	if err != nil {
+		return false, fmt.Errorf("failed to get server version: %w", err)
+	}
+
+	major, err := strconv.Atoi(serverVersion.Major)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse major version %q: %w", serverVersion.Major, err)
+	}
+
+	// Minor version may contain "+" suffix (e.g. "28+")
+	minorStr := serverVersion.Minor
+	for i, c := range minorStr {
+		if c < '0' || c > '9' {
+			minorStr = minorStr[:i]
+			break
+		}
+	}
+	minor, err := strconv.Atoi(minorStr)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse minor version %q: %w", serverVersion.Minor, err)
+	}
+
+	// Native sidecars available in 1.28+ (feature gate), enabled by default in 1.29+
+	return major > 1 || (major == 1 && minor >= 28), nil
+}

--- a/test/e2e/legacy_sidecar_test.go
+++ b/test/e2e/legacy_sidecar_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/sigstore/model-validation-operator/internal/constants"
+	utils "github.com/sigstore/model-validation-operator/test/utils"
+)
+
+const legacySidecarTestNamespace = "e2e-webhook-test-ns"
+
+// defaultLegacyPodData creates a standard pod configuration for legacy sidecar tests
+func defaultLegacyPodData(podName, namespace, modelName string) utils.PodTemplateData {
+	return utils.DefaultPodData(podName, namespace, modelName, "legacy-sidecar")
+}
+
+var _ = Describe("Legacy Sidecar Continuous Validation", Ordered, func() {
+	Context("When operator is running in legacy sidecar mode", func() {
+		BeforeAll(func() {
+			By("enabling force-legacy-sidecar on the operator deployment")
+			cmd := exec.Command("kubectl", "set", "env",
+				"deployment/model-validation-controller-manager",
+				"-n", operatorNamespace,
+				"FORCE_LEGACY_SIDECAR=true")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to set FORCE_LEGACY_SIDECAR env var")
+
+			By("waiting for operator rollout to complete")
+			cmd = exec.Command("kubectl", "rollout", "status",
+				"deployment/model-validation-controller-manager",
+				"-n", operatorNamespace,
+				"--timeout=120s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Operator rollout did not complete")
+
+			By("waiting for new controller pod to be ready")
+			Eventually(func() error {
+				cmd := exec.Command("kubectl", "wait", "pod",
+					"--selector=control-plane=controller-manager",
+					"-n", operatorNamespace,
+					"--for=condition=Ready",
+					"--timeout=60s")
+				_, err := utils.Run(cmd)
+				return err
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			By("removing force-legacy-sidecar from the operator deployment")
+			cmd := exec.Command("kubectl", "set", "env",
+				"deployment/model-validation-controller-manager",
+				"-n", operatorNamespace,
+				"FORCE_LEGACY_SIDECAR-")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to remove FORCE_LEGACY_SIDECAR env var")
+
+			By("waiting for operator rollout to complete")
+			cmd = exec.Command("kubectl", "rollout", "status",
+				"deployment/model-validation-controller-manager",
+				"-n", operatorNamespace,
+				"--timeout=120s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Operator rollout did not complete")
+		})
+
+		It("should inject init container and sidecar for continuous validation", func() {
+			modelName := "legacy-continuous-test"
+			podName := "legacy-sidecar-pod"
+
+			By("deploying a ModelValidation CR with continuous validation enabled")
+			err := utils.KubectlApply(modelValidationContinuousTemplate, utils.CRTemplateData{
+				ModelName: modelName,
+				Namespace: legacySidecarTestNamespace,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deploying a pod with the validation label")
+			err = utils.KubectlApply(podTemplate,
+				defaultLegacyPodData(podName, legacySidecarTestNamespace, modelName))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the init container was injected (one-shot validation)")
+			Eventually(func(g Gomega) {
+				var pod corev1.Pod
+				err := utils.KubectlGetJSON("pod", podName, legacySidecarTestNamespace, &pod)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.Spec.InitContainers).NotTo(BeEmpty())
+				g.Expect(utils.HasValidationContainer(&pod)).To(BeTrue(),
+					"Pod should have validation init container")
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+			By("verifying the legacy sidecar container was injected")
+			Eventually(func(g Gomega) {
+				var pod corev1.Pod
+				err := utils.KubectlGetJSON("pod", podName, legacySidecarTestNamespace, &pod)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(utils.HasValidationSidecar(&pod)).To(BeTrue(),
+					"Pod should have legacy validation sidecar container")
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+			By("verifying init container does NOT have restartPolicy (one-shot mode)")
+			var pod corev1.Pod
+			err = utils.KubectlGetJSON("pod", podName, legacySidecarTestNamespace, &pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, c := range pod.Spec.InitContainers {
+				if c.Name == constants.ModelValidationInitContainerName {
+					Expect(c.RestartPolicy).To(BeNil(),
+						"Init container should not have restartPolicy in legacy mode")
+					break
+				}
+			}
+
+			By("verifying sidecar has --skip-initial and --interval flags")
+			for _, c := range pod.Spec.Containers {
+				if c.Name == constants.ModelValidationSidecarContainerName {
+					Expect(c.Args).To(ContainElement("--skip-initial"),
+						"Sidecar should have --skip-initial flag")
+					Expect(c.Args).To(ContainElement(ContainSubstring("--interval=")),
+						"Sidecar should have --interval flag")
+					Expect(c.ReadinessProbe).NotTo(BeNil(),
+						"Sidecar should have readiness probe")
+					Expect(c.LivenessProbe).NotTo(BeNil(),
+						"Sidecar should have liveness probe")
+					break
+				}
+			}
+
+			By("verifying continuous validation annotation is set")
+			Expect(pod.Annotations[constants.ContinuousValidationAnnotationKey]).To(Equal("true"),
+				"Pod should have continuous validation annotation")
+
+			By("verifying the init container completes successfully (pod reaches Running)")
+			Eventually(func(g Gomega) {
+				var p corev1.Pod
+				err := utils.KubectlGetJSON("pod", podName, legacySidecarTestNamespace, &p)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(p.Status.Phase).To(Equal(corev1.PodRunning),
+					"Pod should be running after init container passes validation")
+			}, 60*time.Second, 5*time.Second).Should(Succeed())
+
+			By("verifying the init container logs show successful validation")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "logs", podName, "-n",
+					legacySidecarTestNamespace, "-c", constants.ModelValidationInitContainerName)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("Verification succeeded"))
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+			By("verifying the sidecar container is running")
+			Eventually(func(g Gomega) {
+				var p corev1.Pod
+				err := utils.KubectlGetJSON("pod", podName, legacySidecarTestNamespace, &p)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Name == constants.ModelValidationSidecarContainerName {
+						g.Expect(cs.State.Running).NotTo(BeNil(),
+							"Sidecar container should be running")
+						g.Expect(cs.Ready).To(BeTrue(),
+							"Sidecar container should be ready (skip-initial marks ready immediately)")
+						return
+					}
+				}
+				g.Expect(false).To(BeTrue(), "Sidecar container status not found")
+			}, 60*time.Second, 5*time.Second).Should(Succeed())
+
+			By("cleaning up test resources")
+			podToDelete := fmt.Sprintf(
+				"apiVersion: v1\nkind: Pod\nmetadata:\n  name: %s\n  namespace: %s",
+				podName, legacySidecarTestNamespace)
+			_ = utils.KubectlDelete([]byte(podToDelete),
+				&utils.KubectlDeleteOptions{Timeout: "30s", IgnoreNotFound: true})
+			crToDelete := fmt.Sprintf(
+				"apiVersion: ml.sigstore.dev/v1alpha1\nkind: ModelValidation\nmetadata:\n  name: %s\n  namespace: %s",
+				modelName, legacySidecarTestNamespace)
+			_ = utils.KubectlDelete([]byte(crToDelete),
+				&utils.KubectlDeleteOptions{Timeout: "30s", IgnoreNotFound: true})
+		})
+	})
+})

--- a/test/e2e/testdata.go
+++ b/test/e2e/testdata.go
@@ -31,5 +31,10 @@ var podTemplate []byte
 //go:embed testdata/curl_metrics_pod_template.yaml
 var curlPodTemplate []byte
 
+// ModelValidation CR template with continuous validation enabled
+//
+//go:embed testdata/modelvalidation_continuous_template.yaml
+var modelValidationContinuousTemplate []byte
+
 //go:embed testdata/clusterrolebinding_template.yaml
 var clusterRoleBindingTemplate []byte

--- a/test/e2e/testdata/modelvalidation_continuous_template.yaml
+++ b/test/e2e/testdata/modelvalidation_continuous_template.yaml
@@ -1,0 +1,16 @@
+apiVersion: ml.sigstore.dev/v1alpha1
+kind: ModelValidation
+metadata:
+  name: {{.ModelName}}
+  namespace: {{.Namespace}}
+spec:
+  config:
+    publicKeyConfig:
+      keyPath: {{if .KeyPath}}{{.KeyPath}}{{else}}/keys/test_public_key.pub{{end}}
+  model:
+    path: /data
+    signaturePath: /data/model.sig
+  imagePullPolicy: IfNotPresent
+  continuousValidation:
+    enabled: true
+    interval: "1m"

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -345,6 +345,17 @@ func HasValidationContainer(pod *corev1.Pod) bool {
 	return false
 }
 
+// HasValidationSidecar checks if a pod has the model-validation-sidecar
+// regular container (used for legacy continuous validation on pre-1.28 clusters)
+func HasValidationSidecar(pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "model-validation-sidecar" {
+			return true
+		}
+	}
+	return false
+}
+
 // CreateServiceAccountToken creates a token for the specified service account in the given namespace
 func CreateServiceAccountToken(serviceAccountName, namespace string) (string, error) {
 	tokenCmd := exec.Command("kubectl", "create", "token", serviceAccountName, "-n", namespace)


### PR DESCRIPTION
## Summary

- Adds automatic Kubernetes version detection to determine native sidecar support (1.28+)
- On pre-1.28 clusters with continuous validation enabled, falls back to injecting a one-shot init container (initial validation) plus a traditional sidecar container (periodic re-validation) instead of using native sidecars
- Adds `--skip-initial` flag to `validation-agent` so the legacy sidecar skips redundant initial validation already performed by the init container

## Changes

| File | Change |
|------|--------|
| `internal/webhooks/version.go` | New — `NativeSidecarSupport()` queries K8s API server version |
| `internal/webhooks/pod_webhook.go` | `NewPodInterceptor` accepts `nativeSidecarSupport` bool; new `buildLegacySidecarContainer`; idempotency check covers both init and regular containers |
| `cmd/validation-agent/main.go` | Added `--skip-initial` flag |
| `cmd/main.go` | Detects native sidecar support at startup, passes to webhook |
| `internal/constants/images.go` | Added `ModelValidationSidecarContainerName` constant |
| `api/v1alpha1/modelvalidation_types.go` | Updated ContinuousValidation docs |
| `internal/webhooks/pod_webhook_legacy_test.go` | New — tests for legacy sidecar path |

## Test plan

- [x] All existing unit tests pass (`make test`)
- [x] New tests cover legacy sidecar build functions, idempotency, and annotation tracking
- [ ] Manual test on a pre-1.28 Kind cluster with continuous validation enabled
- [ ] Manual test on a 1.29+ cluster to verify native sidecar path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)